### PR TITLE
Reverse `H256` on parsing from/to hex string

### DIFF
--- a/btc-types/src/header.rs
+++ b/btc-types/src/header.rs
@@ -2,7 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    hash::{double_sha256, serd_reversed_h256, H256},
+    hash::{double_sha256, H256},
     u256::U256,
 };
 pub type Target = U256;
@@ -13,10 +13,8 @@ pub struct Header {
     /// Block version, now repurposed for soft fork signalling.
     pub version: i32,
     /// Reference to the previous block in the chain.
-    #[serde(with = "serd_reversed_h256")]
     pub prev_block_hash: H256,
     /// The root hash of the merkle tree of transactions in the block.
-    #[serde(with = "serd_reversed_h256")]
     pub merkle_root: H256,
     /// The timestamp of the block, as claimed by the miner.
     pub time: u32,

--- a/merkle-tools/src/lib.rs
+++ b/merkle-tools/src/lib.rs
@@ -62,9 +62,7 @@ mod tests {
     use super::*;
 
     fn decode_hex(hex: &str) -> H256 {
-        let mut hex_decode = hex::decode(hex).unwrap();
-        hex_decode.reverse();
-        H256(hex_decode.try_into().unwrap())
+        hex.parse().unwrap()
     }
 
     // Hash pairs of items recursively until a single value is obtained


### PR DESCRIPTION
Reverse H256 bytes by default on parsing from/to hex string to avoid errors on using this type. 
This is not generic `H256`, so it can be used just for the Bitcoin light project where the hashes are reversed.