### PR TITLE
feat: add Zcash Docker support

### DIFF
--- a/relayer/Dockerfile
+++ b/relayer/Dockerfile
@@ -5,7 +5,14 @@ COPY ./relayer ./relayer
 COPY ./btc-types ./btc-types
 COPY ./merkle-tools ./merkle-tools
 WORKDIR /app/relayer
-RUN cargo build --release
+
+ARG FEATURES=""
+RUN if [ -n "$FEATURES" ]; then \
+        cargo build --release --features "$FEATURES"; \
+    else \
+        cargo build --release; \
+    fi
+
 
 FROM rust:1-slim
 COPY --from=build /app/relayer/target/release/btc-relayer /bin/relayer

--- a/relayer/compose-zec.yaml
+++ b/relayer/compose-zec.yaml
@@ -1,0 +1,30 @@
+name: relayer-zebra
+services:
+  zebra:
+    image: zfnd/zebra:latest
+    platform: linux/amd64
+    environment:
+      NETWORK: Mainnet               # or Testnet
+      ZEBRA_RPC_PORT: 8232           # 18232 on Testnet
+      ENABLE_COOKIE_AUTH: "false"
+    tty: true
+    volumes:
+      - zebra-cache:/home/zebra/.cache/zebra
+    ports:
+      - "8232:8232"
+
+  relayer:
+    build:
+      context: ../
+      dockerfile: ./relayer/Dockerfile
+      args:
+        FEATURES: "zcash"
+    depends_on:
+      - zebra
+    environment:
+      ENDPOINT: "http://zebra:8232"
+      NODE_USER: ""
+      NODE_PASSWORD: ""
+
+volumes:
+  zebra-cache:


### PR DESCRIPTION
* Modified the `relayer/Dockerfile` to accept a `FEATURES` build argument, enabling conditional compilation of the relayer with optional features such as Zcash.
* Added a new `relayer/compose-zec.yaml` file to define a Docker Compose setup for running the relayer alongside the Zebra Zcash node, including service definitions, environment variables, and volume configuration.