### PR TITLE
fix: state migration for layout that included used_aux_parent_blocks

### DIFF
--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
 name = "btc-light-client-contract"
 version = "0.5.0"
 dependencies = [
+ "base64 0.22.1",
  "bitcoin",
  "borsh",
  "btc-types",
@@ -377,6 +378,7 @@ dependencies = [
  "near-sdk",
  "near-workspaces",
  "omni-utils",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -59,6 +59,8 @@ near-workspaces = { version = "0.20.1", features = ["unstable"] }
 tokio = { version = "1.12.0", features = ["full"] }
 serde_json = "1"
 more-asserts = "0.3.1"
+reqwest = { version = "0.12", features = ["json"] }
+base64 = "0.22"
 
 [profile.release]
 codegen-units = 1

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -684,14 +684,26 @@ impl BlocksGetter for BtcLightClient {
 
 mod migrate {
     use crate::{
-        borsh, env, near, BorshDeserialize, BorshSerialize, BtcLightClient, BtcLightClientExt,
+        borsh, env, log, near, BorshDeserialize, BorshSerialize, BtcLightClient, BtcLightClientExt,
         ExtendedHeader, LookupMap, Network, PanicOnDefault, H256,
     };
 
-    /// State layout used between 2025-06 and PR #116, which contained the
-    /// `used_aux_parent_blocks` field in all chain builds.
+    /// State layout used before the `network` field was added in #97.
     #[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
     pub struct BtcLightClientV1 {
+        mainchain_height_to_header: LookupMap<u64, H256>,
+        mainchain_header_to_height: LookupMap<H256, u64>,
+        mainchain_tip_blockhash: H256,
+        mainchain_initial_blockhash: H256,
+        headers_pool: LookupMap<H256, ExtendedHeader>,
+        skip_pow_verification: bool,
+        gc_threshold: u64,
+    }
+
+    /// State layout used between #101 and #116, which contained the
+    /// `used_aux_parent_blocks` field in all chain builds.
+    #[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
+    pub struct BtcLightClientV2 {
         mainchain_height_to_header: LookupMap<u64, H256>,
         mainchain_header_to_height: LookupMap<H256, u64>,
         mainchain_tip_blockhash: H256,
@@ -705,34 +717,67 @@ mod migrate {
 
     #[near]
     impl BtcLightClient {
-        /// Migrates the contract state from `BtcLightClientV1` (the layout that
-        /// included `used_aux_parent_blocks`, removed in PR #116) to the current
-        /// `BtcLightClient` version. The `network` value is carried over from the
-        /// old state, so no arguments are required.
+        /// Migrates the contract state to the current `BtcLightClient` version.
+        ///
+        /// The stored state variant is detected automatically. Borsh requires the
+        /// whole buffer to be consumed, so exactly one of the layouts can parse:
+        /// * current layout: returned unchanged (re-running `migrate` is a no-op)
+        /// * `BtcLightClientV2` (#101..#116): drops `used_aux_parent_blocks`;
+        ///   `network` is carried over from the old state
+        /// * `BtcLightClientV1` (pre-#97): adds `network`, which must be passed
+        ///   as an argument in this case
         ///
         /// Note: any entries stored under the dropped `LookupSet` prefix are left
         /// orphaned in storage. They are only present on Dogecoin deployments;
         /// other chains never wrote to the set.
         ///
         /// # Panics
-        /// This function will panic if reading the old state from storage
-        /// (`env::state_read()`) fails, i.e., if no previous state is found or if
-        /// deserialization fails.
+        /// This function will panic if:
+        /// - No state is found in storage, or it matches none of the known layouts.
+        /// - The state is in the `BtcLightClientV1` layout and `network` is `None`.
         #[private]
         #[init(ignore_state)]
         #[must_use]
-        pub fn migrate() -> Self {
-            let old_state: BtcLightClientV1 = env::state_read().expect("failed");
-            Self {
-                mainchain_height_to_header: old_state.mainchain_height_to_header,
-                mainchain_header_to_height: old_state.mainchain_header_to_height,
-                mainchain_tip_blockhash: old_state.mainchain_tip_blockhash,
-                mainchain_initial_blockhash: old_state.mainchain_initial_blockhash,
-                headers_pool: old_state.headers_pool,
-                skip_pow_verification: old_state.skip_pow_verification,
-                gc_threshold: old_state.gc_threshold,
-                network: old_state.network,
+        pub fn migrate(network: Option<Network>) -> Self {
+            let raw_state = env::storage_read(b"STATE")
+                .unwrap_or_else(|| env::panic_str("contract state not found"));
+
+            if let Ok(state) = <Self as BorshDeserialize>::try_from_slice(&raw_state) {
+                log!("state is already in the current layout");
+                return state;
             }
+
+            if let Ok(old_state) = BtcLightClientV2::try_from_slice(&raw_state) {
+                log!("migrating state from the V2 layout");
+                return Self {
+                    mainchain_height_to_header: old_state.mainchain_height_to_header,
+                    mainchain_header_to_height: old_state.mainchain_header_to_height,
+                    mainchain_tip_blockhash: old_state.mainchain_tip_blockhash,
+                    mainchain_initial_blockhash: old_state.mainchain_initial_blockhash,
+                    headers_pool: old_state.headers_pool,
+                    skip_pow_verification: old_state.skip_pow_verification,
+                    gc_threshold: old_state.gc_threshold,
+                    network: old_state.network,
+                };
+            }
+
+            if let Ok(old_state) = BtcLightClientV1::try_from_slice(&raw_state) {
+                log!("migrating state from the V1 layout");
+                return Self {
+                    mainchain_height_to_header: old_state.mainchain_height_to_header,
+                    mainchain_header_to_height: old_state.mainchain_header_to_height,
+                    mainchain_tip_blockhash: old_state.mainchain_tip_blockhash,
+                    mainchain_initial_blockhash: old_state.mainchain_initial_blockhash,
+                    headers_pool: old_state.headers_pool,
+                    skip_pow_verification: old_state.skip_pow_verification,
+                    gc_threshold: old_state.gc_threshold,
+                    network: network.unwrap_or_else(|| {
+                        env::panic_str("network argument is required to migrate from V1 state")
+                    }),
+                };
+            }
+
+            env::panic_str("contract state matches no known layout")
         }
     }
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -688,18 +688,6 @@ mod migrate {
         ExtendedHeader, LookupMap, Network, PanicOnDefault, H256,
     };
 
-    /// State layout used before the `network` field was added in #97.
-    #[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
-    pub struct BtcLightClientV1 {
-        mainchain_height_to_header: LookupMap<u64, H256>,
-        mainchain_header_to_height: LookupMap<H256, u64>,
-        mainchain_tip_blockhash: H256,
-        mainchain_initial_blockhash: H256,
-        headers_pool: LookupMap<H256, ExtendedHeader>,
-        skip_pow_verification: bool,
-        gc_threshold: u64,
-    }
-
     /// State layout used between #101 and #116, which contained the
     /// `used_aux_parent_blocks` field in all chain builds.
     #[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
@@ -724,21 +712,18 @@ mod migrate {
         /// * current layout: returned unchanged (re-running `migrate` is a no-op)
         /// * `BtcLightClientV2` (#101..#116): drops `used_aux_parent_blocks`;
         ///   `network` is carried over from the old state
-        /// * `BtcLightClientV1` (pre-#97): adds `network`, which must be passed
-        ///   as an argument in this case
         ///
         /// Note: any entries stored under the dropped `LookupSet` prefix are left
         /// orphaned in storage. They are only present on Dogecoin deployments;
         /// other chains never wrote to the set.
         ///
         /// # Panics
-        /// This function will panic if:
-        /// - No state is found in storage, or it matches none of the known layouts.
-        /// - The state is in the `BtcLightClientV1` layout and `network` is `None`.
+        /// This function will panic if no state is found in storage, or it
+        /// matches none of the known layouts.
         #[private]
         #[init(ignore_state)]
         #[must_use]
-        pub fn migrate(network: Option<Network>) -> Self {
+        pub fn migrate() -> Self {
             let raw_state = env::storage_read(b"STATE")
                 .unwrap_or_else(|| env::panic_str("contract state not found"));
 
@@ -758,22 +743,6 @@ mod migrate {
                     skip_pow_verification: old_state.skip_pow_verification,
                     gc_threshold: old_state.gc_threshold,
                     network: old_state.network,
-                };
-            }
-
-            if let Ok(old_state) = BtcLightClientV1::try_from_slice(&raw_state) {
-                log!("migrating state from the V1 layout");
-                return Self {
-                    mainchain_height_to_header: old_state.mainchain_height_to_header,
-                    mainchain_header_to_height: old_state.mainchain_header_to_height,
-                    mainchain_tip_blockhash: old_state.mainchain_tip_blockhash,
-                    mainchain_initial_blockhash: old_state.mainchain_initial_blockhash,
-                    headers_pool: old_state.headers_pool,
-                    skip_pow_verification: old_state.skip_pow_verification,
-                    gc_threshold: old_state.gc_threshold,
-                    network: network.unwrap_or_else(|| {
-                        env::panic_str("network argument is required to migrate from V1 state")
-                    }),
                 };
             }
 

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -688,6 +688,8 @@ mod migrate {
         ExtendedHeader, LookupMap, Network, PanicOnDefault, H256,
     };
 
+    /// State layout used between 2025-06 and PR #116, which contained the
+    /// `used_aux_parent_blocks` field in all chain builds.
     #[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
     pub struct BtcLightClientV1 {
         mainchain_height_to_header: LookupMap<u64, H256>,
@@ -697,27 +699,29 @@ mod migrate {
         headers_pool: LookupMap<H256, ExtendedHeader>,
         skip_pow_verification: bool,
         gc_threshold: u64,
+        used_aux_parent_blocks: near_sdk::collections::LookupSet<H256>,
+        network: Network,
     }
 
     #[near]
     impl BtcLightClient {
-        /// Migrates the contract state from `BtcLightClientV1` to the current `BtcLightClient` version.
+        /// Migrates the contract state from `BtcLightClientV1` (the layout that
+        /// included `used_aux_parent_blocks`, removed in PR #116) to the current
+        /// `BtcLightClient` version. The `network` value is carried over from the
+        /// old state, so no arguments are required.
         ///
-        /// This function reads the old contract state and constructs the new contract instance
-        /// with updated fields.
-        ///
-        /// # Arguments
-        /// * `network` - The network identifier (e.g., Mainnet, Testnet) to use in the new state.
-        ///
-        /// # Returns
-        /// A new `BtcLightClient` instance containing the migrated state.
+        /// Note: any entries stored under the dropped `LookupSet` prefix are left
+        /// orphaned in storage. They are only present on Dogecoin deployments;
+        /// other chains never wrote to the set.
         ///
         /// # Panics
-        /// This function will panic if:
-        /// - Reading the old state from storage (`env::state_read()`) fails, i.e., if no previous state is found or if deserialization fails.
+        /// This function will panic if reading the old state from storage
+        /// (`env::state_read()`) fails, i.e., if no previous state is found or if
+        /// deserialization fails.
         #[private]
         #[init(ignore_state)]
-        pub fn migrate(network: Network) -> Self {
+        #[must_use]
+        pub fn migrate() -> Self {
             let old_state: BtcLightClientV1 = env::state_read().expect("failed");
             Self {
                 mainchain_height_to_header: old_state.mainchain_height_to_header,
@@ -727,7 +731,7 @@ mod migrate {
                 headers_pool: old_state.headers_pool,
                 skip_pow_verification: old_state.skip_pow_verification,
                 gc_threshold: old_state.gc_threshold,
-                network,
+                network: old_state.network,
             }
         }
     }

--- a/contract/tests/test_basics.rs
+++ b/contract/tests/test_basics.rs
@@ -146,6 +146,109 @@ mod test_basics {
         result
     }
 
+    /// Fetches the wasm currently deployed on a mainnet account via plain RPC.
+    /// (`near_workspaces::mainnet()` is not used because its client fails to
+    /// parse responses from current mainnet nodes.)
+    async fn fetch_mainnet_wasm(account_id: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        use base64::Engine;
+
+        let response: serde_json::Value = reqwest::Client::new()
+            .post("https://rpc.mainnet.near.org")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": "dontcare",
+                "method": "query",
+                "params": {
+                    "request_type": "view_code",
+                    "finality": "final",
+                    "account_id": account_id,
+                },
+            }))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        let code_base64 = response["result"]["code_base64"]
+            .as_str()
+            .unwrap_or_else(|| panic!("no code_base64 in response: {response}"));
+        Ok(base64::engine::general_purpose::STANDARD.decode(code_base64)?)
+    }
+
+    /// Initializes a sandbox contract from the wasm currently deployed on
+    /// mainnet (`btc-client.bridge.near`, which is already on the current state
+    /// layout), upgrades it to the locally built wasm and verifies that
+    /// `migrate` detects the up-to-date layout and keeps the state intact.
+    #[tokio::test]
+    async fn test_migration_from_mainnet_wasm() -> Result<(), Box<dyn std::error::Error>> {
+        let sandbox = near_workspaces::sandbox().await?;
+        let old_wasm = fetch_mainnet_wasm("btc-client.bridge.near").await?;
+
+        let contract = sandbox.dev_deploy(&old_wasm).await?;
+
+        let submit_blocks = make_init_submit_blocks();
+        let args = InitArgs {
+            genesis_block_hash: submit_blocks[0].block_hash(),
+            genesis_block_height: 0,
+            skip_pow_verification: true,
+            gc_threshold: 20,
+            network: btc_types::network::Network::Mainnet,
+            submit_blocks,
+        };
+        let outcome = contract
+            .call("init")
+            .args_json(json!({ "args": serde_json::to_value(args).unwrap() }))
+            .transact()
+            .await?;
+        assert!(outcome.is_success(), "{:?}", outcome.failures());
+
+        let header_before_upgrade = contract
+            .view("get_last_block_header")
+            .args_json(json!({}))
+            .await?
+            .json::<ExtendedHeader>()?;
+
+        // Upgrade to the current wasm and migrate. The mainnet contract was
+        // already migrated to the current layout, so this exercises the
+        // "state is already in the current layout" no-op path.
+        let new_wasm = near_workspaces::compile_project("./").await?;
+        contract
+            .as_account()
+            .deploy(&new_wasm)
+            .await?
+            .into_result()?;
+
+        let outcome = contract
+            .call("migrate")
+            .args_json(json!({ "network": null }))
+            .max_gas()
+            .transact()
+            .await?;
+        assert!(outcome.is_success(), "{:?}", outcome.failures());
+
+        // State is intact after the migration and the contract is functional.
+        let last_header = contract
+            .view("get_last_block_header")
+            .args_json(json!({}))
+            .await?
+            .json::<ExtendedHeader>()?;
+        assert_eq!(last_header, header_before_upgrade);
+
+        let user_account = sandbox.dev_create_account().await?;
+        grant_relayer_role(&contract, &user_account).await?;
+        let (main_block, _, _) = make_reorg_test_blocks();
+        let outcome = user_account
+            .call(contract.id(), "submit_blocks")
+            .args_borsh(vec![main_block])
+            .max_gas()
+            .deposit(STORAGE_DEPOSIT_PER_BLOCK)
+            .transact()
+            .await?;
+        assert!(outcome.is_success(), "{:?}", outcome.failures());
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_setting_genesis_block() -> Result<(), Box<dyn std::error::Error>> {
         let (contract, _user_account) = init_contract().await?;

--- a/contract/tests/test_basics.rs
+++ b/contract/tests/test_basics.rs
@@ -220,7 +220,7 @@ mod test_basics {
 
         let outcome = contract
             .call("migrate")
-            .args_json(json!({ "network": null }))
+            .args_json(json!({}))
             .max_gas()
             .transact()
             .await?;

--- a/contract/tests/test_zcash.rs
+++ b/contract/tests/test_zcash.rs
@@ -170,7 +170,7 @@ mod test_zcash {
 
         let outcome = contract
             .call("migrate")
-            .args_json(json!({ "network": null }))
+            .args_json(json!({}))
             .max_gas()
             .transact()
             .await?;

--- a/contract/tests/test_zcash.rs
+++ b/contract/tests/test_zcash.rs
@@ -94,6 +94,110 @@ mod test_zcash {
         serde_json::from_reader(reader).expect("Unable to parse JSON")
     }
 
+    /// Fetches the wasm currently deployed on a mainnet account via plain RPC.
+    /// (`near_workspaces::mainnet()` is not used because its client fails to
+    /// parse responses from current mainnet nodes.)
+    async fn fetch_mainnet_wasm(account_id: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        use base64::Engine;
+
+        let response: serde_json::Value = reqwest::Client::new()
+            .post("https://rpc.mainnet.near.org")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": "dontcare",
+                "method": "query",
+                "params": {
+                    "request_type": "view_code",
+                    "finality": "final",
+                    "account_id": account_id,
+                },
+            }))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        let code_base64 = response["result"]["code_base64"]
+            .as_str()
+            .unwrap_or_else(|| panic!("no code_base64 in response: {response}"));
+        Ok(base64::engine::general_purpose::STANDARD.decode(code_base64)?)
+    }
+
+    /// Initializes a sandbox contract from the wasm currently deployed on
+    /// mainnet (`zcash-client.bridge.near`, built before #116, whose state
+    /// layout still contains `used_aux_parent_blocks`), upgrades it to the
+    /// locally built wasm and verifies that `migrate` repairs the state.
+    #[tokio::test]
+    async fn test_migration_from_mainnet_wasm() -> Result<(), Box<dyn std::error::Error>> {
+        let sandbox = near_workspaces::sandbox().await?;
+        let old_wasm = fetch_mainnet_wasm("zcash-client.bridge.near").await?;
+
+        let contract = sandbox.dev_deploy(&old_wasm).await?;
+
+        let initial_blocks = read_zcash_blocks();
+        let args = InitArgs {
+            genesis_block_hash: initial_blocks[0].block_hash(),
+            genesis_block_height: 2940821,
+            skip_pow_verification: false,
+            gc_threshold: 2000,
+            network: btc_types::network::Network::Mainnet,
+            submit_blocks: initial_blocks[..29].to_vec(),
+        };
+        let outcome = contract
+            .call("init")
+            .args_json(json!({ "args": serde_json::to_value(args).unwrap() }))
+            .max_gas()
+            .transact()
+            .await?;
+        assert!(outcome.is_success(), "{:?}", outcome.failures());
+
+        // Upgrade to the current wasm. The old state layout contains
+        // `used_aux_parent_blocks`, so without a migration every call fails.
+        let new_wasm = build_contract().await;
+        contract
+            .as_account()
+            .deploy(&new_wasm)
+            .await?
+            .into_result()?;
+
+        let outcome = contract
+            .view("get_last_block_header")
+            .args_json(json!({}))
+            .await;
+        assert!(
+            format!("{:?}", outcome.unwrap_err()).contains("Cannot deserialize the contract state")
+        );
+
+        let outcome = contract
+            .call("migrate")
+            .args_json(json!({ "network": null }))
+            .max_gas()
+            .transact()
+            .await?;
+        assert!(outcome.is_success(), "{:?}", outcome.failures());
+
+        // State is intact after the migration and the contract is functional.
+        let last_header = contract
+            .view("get_last_block_header")
+            .args_json(json!({}))
+            .await?
+            .json::<ExtendedHeader>()?;
+        assert_eq!(last_header.block_header, initial_blocks[28].clone().into());
+
+        let user_account = sandbox.dev_create_account().await?;
+        grant_relayer_role(&contract, &user_account).await?;
+        let outcome = user_account
+            .call(contract.id(), "submit_blocks")
+            .args_borsh(initial_blocks[29..32].to_vec())
+            .max_gas()
+            .deposit(STORAGE_DEPOSIT_PER_BLOCK.saturating_mul(3))
+            .transact()
+            .await?;
+        assert!(outcome.is_success(), "{:?}", outcome.failures());
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_init() -> Result<(), Box<dyn std::error::Error>> {
         let (contract, _user_account) = init_zcash_contract().await?;


### PR DESCRIPTION
## Problem

The zcash testnet relayer is down: every call to `zcash-client.n-bridge.testnet` panics with `Cannot deserialize the contract state` since the 2026-06-10 release deploy.

#116 removed the unconditional `used_aux_parent_blocks: LookupSet<H256>` field from the contract state struct without adding a migration. Any contract **initialized between #101 (2025-06-06) and #116 (2026-03-18)** carries that field in its on-chain state, so deploying current wasm over it makes borsh state deserialization fail on every method call.

Survey of all deployments:

| account | initialized | state layout |
|---|---|---|
| `btc-client.bridge.near` | 2024-09 | current (migrated 2026-04-02) |
| `btc-client-v4.testnet` | 2024-09 | current (migrated 2026-03-27) |
| `zcash-client.n-bridge.testnet` | 2025-06-27 | old (`used_aux_parent_blocks`) — **currently down** |
| `zcash-client.bridge.near` | 2025-08-20 | old — breaks on next upgrade |
| `litecoin-client.n-bridge.testnet` | 2025-07-06 | old — breaks on next upgrade |

## Fix

`migrate()` (no arguments) auto-detects the stored state variant (borsh requires full buffer consumption, so exactly one layout can parse):

- current layout → no-op, re-running `migrate` is safe
- `BtcLightClientV2` (#101..#116, has `used_aux_parent_blocks`) → drops the field, `network` is carried over from state

The pre-#97 layout (no `network` field) is not handled: no deployment is on it anymore.

## Tests

Both tests pull the **wasm currently deployed on mainnet**, init it in a sandbox, upgrade to the locally built wasm and call `migrate`:

- `test_zcash::test_migration_from_mainnet_wasm` — `zcash-client.bridge.near` wasm (pre-#116 layout): verifies calls fail before migration with the exact production error, succeed after, and that headers/submissions survive.
- `test_basics::test_migration_from_mainnet_wasm` — `btc-client.bridge.near` wasm (already current layout): verifies the no-op path keeps state intact.

The wasm is fetched via plain JSON-RPC because `near_workspaces::mainnet()` (0.20.1) fails to parse responses from current mainnet nodes.

## Deployment

After merge: `make build-zcash`, deploy to `zcash-client.n-bridge.testnet` with a batched `migrate` call (`{}`). The same migration is required for `zcash-client.bridge.near` and `litecoin-client.n-bridge.testnet` with their next upgrades.

## Notes

- Entries under the dropped `LookupSet` prefix are left orphaned; only Dogecoin deployments ever wrote to it, and none exist. If a Dogecoin contract initialized in the #101..#116 era ever surfaces, it needs more than this: `ExtendedHeader` also lost its `aux_parent_block` field in #116, so its `headers_pool` entries have a stale layout too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)